### PR TITLE
Suppress unpacking for our supported archetypes

### DIFF
--- a/seqware-archetypes/seqware-archetype-java-workflow/src/main/resources/archetype-resources/pom.xml
+++ b/seqware-archetypes/seqware-archetype-java-workflow/src/main/resources/archetype-resources/pom.xml
@@ -53,6 +53,7 @@
             <groupId>com.github.seqware</groupId>
             <artifactId>seqware-pipeline</artifactId>
             <version>${seqware-version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 
@@ -212,6 +213,7 @@
                             <outputDirectory>${project.build.directory}/Workflow_Bundle_${workflow-directory-name}_${project.version}_SeqWare_${seqware-version}/Workflow_Bundle_${workflow-directory-name}/${symbol_dollar}{project.version}/bin</outputDirectory>
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>true</overWriteSnapshots>
+                            <excludeScope>provided</excludeScope>
                         </configuration>
                     </execution>
                 </executions>

--- a/seqware-archetypes/seqware-archetype-simplified-ftl-workflow/src/main/resources/archetype-resources/pom.xml
+++ b/seqware-archetypes/seqware-archetype-simplified-ftl-workflow/src/main/resources/archetype-resources/pom.xml
@@ -49,6 +49,7 @@
             <groupId>com.github.seqware</groupId>
             <artifactId>seqware-pipeline</artifactId>
             <version>${seqware-version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 
@@ -207,6 +208,7 @@
                             <outputDirectory>${project.build.directory}/Workflow_Bundle_${workflow-name}_${project.version}_SeqWare_${seqware-version}/Workflow_Bundle_${workflow-directory-name}/${symbol_dollar}{project.version}/bin</outputDirectory>
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>true</overWriteSnapshots>
+                            <excludeScope>provided</excludeScope>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Not a whole lot to talk about here. 
Suppressing the expansion of our pipeline and distribution jars seems to work fine using the oozie engine.
