### PR TITLE
Revert "Add --wait to the test command inside the bundle archetype's met...

### DIFF
--- a/seqware-archetypes/seqware-archetype-java-workflow/src/main/resources/archetype-resources/workflow/metadata.xml
+++ b/seqware-archetypes/seqware-archetype-java-workflow/src/main/resources/archetype-resources/workflow/metadata.xml
@@ -2,7 +2,7 @@
   <workflow name="${workflow-name}" version="${workflow-version}" seqware_version="${seqware-version}"
   basedir="${workflow_bundle_dir}/Workflow_Bundle_${workflow-directory-name}/${version}">
     <description>${workflow-description}</description>
-    <test command="java -jar ${workflow_bundle_dir}/Workflow_Bundle_${workflow-directory-name}/${version}/lib/seqware-distribution-${seqware-version}-full.jar --plugin net.sourceforge.seqware.pipeline.plugins.WorkflowLauncher -- --no-metadata --wait --provisioned-bundle-dir ${workflow_bundle_dir} --workflow ${workflow-name} --version ${workflow-version} --ini-files ${workflow_bundle_dir}/Workflow_Bundle_${workflow-directory-name}/${version}/config/workflow.ini "/>
+    <test command="java -jar ${workflow_bundle_dir}/Workflow_Bundle_${workflow-directory-name}/${version}/lib/seqware-distribution-${seqware-version}-full.jar --plugin net.sourceforge.seqware.pipeline.plugins.WorkflowLauncher -- --no-metadata --provisioned-bundle-dir ${workflow_bundle_dir} --workflow ${workflow-name} --version ${workflow-version} --ini-files ${workflow_bundle_dir}/Workflow_Bundle_${workflow-directory-name}/${version}/config/workflow.ini "/>
     <workflow_command command="java -jar ${workflow_bundle_dir}/Workflow_Bundle_${workflow-directory-name}/${version}/lib/seqware-distribution-${seqware-version}-full.jar --plugin net.sourceforge.seqware.pipeline.plugins.WorkflowLauncher -- --bundle ${workflow_bundle_dir} --workflow ${workflow-name} --version ${workflow-version} "/>
     <workflow_template path=""/>
     <workflow_class path="${workflow_bundle_dir}/Workflow_Bundle_${workflow-directory-name}/${version}/classes/${workflow-package}/WorkflowClient.java"/>


### PR DESCRIPTION
...adata.xml."

This reverts commit 0ee1242f83f3d6b9e5fc415ba42557291164d363.

The original change was not the appropriate fix.  The "waiting" during a test should be in the process that kicks off the test launch, thus the test launch itself does not need to wait.  With this change, testing a bundle against oozie will immediately return (since the code to poll status is pegasus-specific).  Opening a separate ticket for that feature.
