### PR TITLE
SEQWARE-1783 : Admin webservice sw_accession generation

### DIFF
--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/Expense.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/Expense.java
@@ -74,7 +74,7 @@ public class Expense implements Serializable {
   private BigInteger totalPrice;
   @Column(name = "added_surcharge")
   private BigInteger addedSurcharge;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @Column(name = "expense_finished_tstmp")
   @Temporal(TemporalType.TIMESTAMP)

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/Experiment.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/Experiment.java
@@ -110,7 +110,7 @@ public class Experiment implements Serializable {
   private BigInteger expectedNumberSpots;
   @Column(name = "expected_number_reads")
   private BigInteger expectedNumberReads;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @Basic(optional = false)
   @NotNull

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/File.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/File.java
@@ -84,7 +84,7 @@ public class File implements Serializable {
   @Size(max = 2147483647)
   @Column(name = "description")
   private String description;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @Column(name = "size")
   private BigInteger size;

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/Invoice.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/Invoice.java
@@ -88,7 +88,7 @@ public class Invoice implements Serializable {
   @Size(max = 2147483647)
   @Column(name = "notes")
   private String notes;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @Basic(optional = false)
   @NotNull

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/Ius.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/Ius.java
@@ -67,7 +67,7 @@ public class Ius implements Serializable {
   @Size(max = 2147483647)
   @Column(name = "tag")
   private String tag;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @Basic(optional = false)
   @NotNull

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/Lane.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/Lane.java
@@ -87,7 +87,7 @@ public class Lane implements Serializable {
   @Size(max = 2147483647)
   @Column(name = "regions")
   private String regions;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @Basic(optional = false)
   @NotNull

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/Processing.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/Processing.java
@@ -99,7 +99,7 @@ public class Processing implements Serializable {
   private Integer processExitStatus;
   @Column(name = "task_group")
   private Boolean taskGroup;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @Column(name = "run_start_tstmp")
   @Temporal(TemporalType.TIMESTAMP)

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ProcessingExperiments.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ProcessingExperiments.java
@@ -50,7 +50,7 @@ public class ProcessingExperiments implements Serializable {
   @Size(max = 2147483647)
   @Column(name = "url")
   private String url;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @JoinColumn(name = "processing_id", referencedColumnName = "processing_id")
   @ManyToOne(optional = false)

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ProcessingIus.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ProcessingIus.java
@@ -50,7 +50,7 @@ public class ProcessingIus implements Serializable {
   @Size(max = 2147483647)
   @Column(name = "url")
   private String url;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @JoinColumn(name = "processing_id", referencedColumnName = "processing_id")
   @ManyToOne(optional = false)

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ProcessingLanes.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ProcessingLanes.java
@@ -50,7 +50,7 @@ public class ProcessingLanes implements Serializable {
   @Size(max = 2147483647)
   @Column(name = "url")
   private String url;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @JoinColumn(name = "processing_id", referencedColumnName = "processing_id")
   @ManyToOne(optional = false)

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ProcessingSamples.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ProcessingSamples.java
@@ -50,7 +50,7 @@ public class ProcessingSamples implements Serializable {
   @Size(max = 2147483647)
   @Column(name = "url")
   private String url;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @JoinColumn(name = "sample_id", referencedColumnName = "sample_id")
   @ManyToOne(optional = false)

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ProcessingSequencerRuns.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ProcessingSequencerRuns.java
@@ -50,7 +50,7 @@ public class ProcessingSequencerRuns implements Serializable {
   @Size(max = 2147483647)
   @Column(name = "url")
   private String url;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @JoinColumn(name = "sequencer_run_id", referencedColumnName = "sequencer_run_id")
   @ManyToOne(optional = false)

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ProcessingStudies.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ProcessingStudies.java
@@ -50,7 +50,7 @@ public class ProcessingStudies implements Serializable {
   @Size(max = 2147483647)
   @Column(name = "url")
   private String url;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @JoinColumn(name = "study_id", referencedColumnName = "study_id")
   @ManyToOne(optional = false)

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/Sample.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/Sample.java
@@ -118,7 +118,7 @@ public class Sample implements Serializable {
   private Boolean skip;
   @Column(name = "is_public")
   private Boolean isPublic;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @Basic(optional = false)
   @NotNull

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/SequencerRun.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/SequencerRun.java
@@ -142,7 +142,7 @@ public class SequencerRun implements Serializable {
   @Size(max = 2147483647)
   @Column(name = "quality_scorer")
   private String qualityScorer;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @Basic(optional = false)
   @NotNull

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ShareExperiment.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ShareExperiment.java
@@ -44,7 +44,7 @@ public class ShareExperiment implements Serializable {
   private Integer shareExperimentId;
   @Column(name = "active")
   private Boolean active;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @Basic(optional = false)
   @NotNull

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ShareFile.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ShareFile.java
@@ -39,7 +39,7 @@ public class ShareFile implements Serializable {
   private static final long serialVersionUID = 1L;
   @Column(name = "active")
   private Boolean active;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @Basic(optional = false)
   @NotNull

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ShareLane.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ShareLane.java
@@ -39,7 +39,7 @@ public class ShareLane implements Serializable {
   private static final long serialVersionUID = 1L;
   @Column(name = "active")
   private Boolean active;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @Basic(optional = false)
   @NotNull

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ShareProcessing.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ShareProcessing.java
@@ -39,7 +39,7 @@ public class ShareProcessing implements Serializable {
   private static final long serialVersionUID = 1L;
   @Column(name = "active")
   private Boolean active;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @Basic(optional = false)
   @NotNull

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ShareSample.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ShareSample.java
@@ -39,7 +39,7 @@ public class ShareSample implements Serializable {
   private static final long serialVersionUID = 1L;
   @Column(name = "active")
   private Boolean active;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @Basic(optional = false)
   @NotNull

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ShareStudy.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ShareStudy.java
@@ -46,7 +46,7 @@ public class ShareStudy implements Serializable {
   private Integer shareStudyId;
   @Column(name = "active")
   private Boolean active;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @Basic(optional = false)
   @NotNull

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ShareWorkflowRun.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/ShareWorkflowRun.java
@@ -46,7 +46,7 @@ public class ShareWorkflowRun implements Serializable {
   private Integer shareWorkflowRunId;
   @Column(name = "active")
   private Boolean active;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @Basic(optional = false)
   @NotNull

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/Study.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/Study.java
@@ -98,7 +98,7 @@ public class Study implements Serializable {
   @Size(max = 2147483647)
   @Column(name = "status")
   private String status;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @Basic(optional = false)
   @NotNull

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/Workflow.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/Workflow.java
@@ -106,7 +106,7 @@ public class Workflow implements Serializable {
   @Column(name = "update_tstmp")
   @Version
   private Timestamp updateTstmp;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @Size(max = 2147483647)
   @Column(name = "permanent_bundle_location")

--- a/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/WorkflowRun.java
+++ b/seqware-admin-webservice/src/main/java/io/seqware/webservice/generated/model/WorkflowRun.java
@@ -116,7 +116,7 @@ public class WorkflowRun implements Serializable {
   @Column(name = "update_tstmp")
   @Version
   private Timestamp updateTstmp;
-  @Column(name = "sw_accession")
+  @Column(name = "sw_accession", insertable=false,updatable=false)
   private Integer swAccession;
   @Size(max = 2147483647)
   @Column(name = "workflow_engine")


### PR DESCRIPTION
Turns out, sw_accession is generated database side and not in the ORM layer.
All we need to do is ignore insert, update, and let the database do the rest.
