### PR TITLE
Improve exception messaging when dealing with workflows that fail to launch due to exceptions in user code

### DIFF
--- a/seqware-pipeline/src/main/java/io/seqware/WorkflowRuns.java
+++ b/seqware-pipeline/src/main/java/io/seqware/WorkflowRuns.java
@@ -4,6 +4,9 @@ import net.sourceforge.seqware.common.metadata.Metadata;
 import net.sourceforge.seqware.common.metadata.MetadataFactory;
 import net.sourceforge.seqware.common.model.WorkflowRun;
 import net.sourceforge.seqware.common.model.WorkflowRunStatus;
+import static net.sourceforge.seqware.common.model.WorkflowRunStatus.pending;
+import static net.sourceforge.seqware.common.model.WorkflowRunStatus.running;
+import static net.sourceforge.seqware.common.model.WorkflowRunStatus.submitted;
 import net.sourceforge.seqware.common.util.configtools.ConfigTools;
 
 public class WorkflowRuns {
@@ -24,6 +27,13 @@ public class WorkflowRuns {
       throw new UnsupportedOperationException("Workflow run cancellation not supported for engine: "
                                               + wr.getWorkflowEngine());
     }
+  }
+  
+  public static void failWorkflow(int workflowRunAccession) {
+    Metadata md = MetadataFactory.get(ConfigTools.getSettings());
+    WorkflowRun wr = md.getWorkflowRun(workflowRunAccession);
+    wr.setStatus(WorkflowRunStatus.failed);
+    md.updateWorkflowRun(wr);
   }
 
   public static void submitRetry(int workflowRunAccession) {

--- a/seqware-pipeline/src/main/java/net/sourceforge/seqware/pipeline/plugin/WorkflowPlugin.java
+++ b/seqware-pipeline/src/main/java/net/sourceforge/seqware/pipeline/plugin/WorkflowPlugin.java
@@ -11,6 +11,7 @@
  */
 package net.sourceforge.seqware.pipeline.plugin;
 
+import io.seqware.WorkflowRuns;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -521,7 +522,10 @@ public class WorkflowPlugin extends Plugin {
         workflowEngine = dataModel.getWorkflow_engine();
       }
     } catch (Exception e) {
-      Log.fatal(e, e);
+      if (workflowRunAccession != null){
+        Log.fatal("Exception constructing data model, failing workflow " + workflowRunAccession, e);
+        WorkflowRuns.failWorkflow(workflowRunAccession);
+      }
       ret.setExitStatus(ReturnValue.INVALIDARGUMENT);
       return ret;
     }

--- a/seqware-pipeline/src/main/java/net/sourceforge/seqware/pipeline/workflowV2/WorkflowDataModelFactory.java
+++ b/seqware-pipeline/src/main/java/net/sourceforge/seqware/pipeline/workflowV2/WorkflowDataModelFactory.java
@@ -18,6 +18,7 @@ import net.sourceforge.seqware.common.model.WorkflowParam;
 import net.sourceforge.seqware.common.model.WorkflowRun;
 import net.sourceforge.seqware.common.module.ReturnValue;
 import net.sourceforge.seqware.common.util.Log;
+import net.sourceforge.seqware.common.util.Rethrow;
 import net.sourceforge.seqware.common.util.maptools.MapTools;
 import net.sourceforge.seqware.common.util.workflowtools.WorkflowInfo;
 import net.sourceforge.seqware.pipeline.bundle.Bundle;
@@ -247,15 +248,20 @@ public class WorkflowDataModelFactory {
                 m = clazz.getMethod("buildWorkflow");
                 m.invoke(dataModel);
             } catch (SecurityException e) {
-                Log.error(e);
+                Log.error("SecurityException",e);
+                Rethrow.rethrow(e);
             } catch (NoSuchMethodException e) {
-                Log.error(e);
+                Log.error("NoSuchMethodException",e);
+                Rethrow.rethrow(e);
             } catch (IllegalArgumentException e) {
-                Log.error(e);
+                Log.error("IllegalArgumentException",e);
+                Rethrow.rethrow(e);
             } catch (IllegalAccessException e) {
-                Log.error(e);
+                Log.error("IllegalAccessException",e);
+                Rethrow.rethrow(e);
             } catch (InvocationTargetException e) {
-                Log.error(e);
+                Log.error("InvocationTargetException",e);
+                Rethrow.rethrow(e);
             }
         } else {
             WorkflowXmlParser xmlParser = new WorkflowXmlParser();


### PR DESCRIPTION
1) Stack traces are provided when creating workflows (that create exceptions)
2) Workflow launcher will terminate when stopping on exception (when launching single bundles)
3) Workflow launcher will report stack traces for workflows when launching scheduled bundles and set the status to 'failed'
