### PR TITLE
Hardcoded in one of the workflow accessions from the testdata

### DIFF
--- a/seqware-webservice/src/test/java/net/sourceforge/seqware/pipeline/plugins/BatchMetadataInjectionTest.java
+++ b/seqware-webservice/src/test/java/net/sourceforge/seqware/pipeline/plugins/BatchMetadataInjectionTest.java
@@ -75,7 +75,7 @@ public class BatchMetadataInjectionTest extends ExtendedPluginTest {
     private static String malformedJson = null;
     private static InputStream schema = null;
 
-    private final String wfaccession = String.valueOf("2861");
+    private final String wfaccession = "2861";
 
     public BatchMetadataInjectionTest() {
     }


### PR DESCRIPTION
Sorry about the large amount of PRs
