### PR TITLE
Trim memory for automatically generated start_0 and single file

### DIFF
--- a/seqware-archetypes/seqware-archetype-java-workflow/src/main/resources/archetype-resources/src/main/java/__workflow-name__Workflow.java
+++ b/seqware-archetypes/seqware-archetype-java-workflow/src/main/resources/archetype-resources/src/main/java/__workflow-name__Workflow.java
@@ -78,20 +78,21 @@ public class ${workflow-name}Workflow extends AbstractWorkflowDataModel {
 
         // a simple bash job to call mkdir
 	// note that this job uses the system's mkdir (which depends on the system being *nix)
-        Job mkdirJob = this.getWorkflow().createBashJob("bash_mkdir").setMaxMemory("2500");
+	// this also translates into a 3000 h_vmem limit when using sge 
+        Job mkdirJob = this.getWorkflow().createBashJob("bash_mkdir").setMaxMemory("3000");
         mkdirJob.getCommand().addArgument("mkdir test1");      
        
 	String inputFilePath = this.getFiles().get("file_in_0").getProvisionedPath();
 	 
         // a simple bash job to cat a file into a test file
 	// the file is not saved to the metadata database
-        Job copyJob1 = this.getWorkflow().createBashJob("bash_cp").setMaxMemory("2500");
+        Job copyJob1 = this.getWorkflow().createBashJob("bash_cp").setMaxMemory("3000");
         copyJob1.setCommand(catPath + " " + inputFilePath + "> test1/test.out");
         copyJob1.addParent(mkdirJob);
         
         // a simple bash job to echo to an output file and concat an input file
 	// the file IS saved to the metadata database
-        Job copyJob2 = this.getWorkflow().createBashJob("bash_cp").setMaxMemory("2500");
+        Job copyJob2 = this.getWorkflow().createBashJob("bash_cp").setMaxMemory("3000");
 	copyJob2.getCommand().addArgument(echoPath).addArgument(greeting).addArgument(" > ").addArgument("dir1/output");
 	copyJob2.getCommand().addArgument(";");
 	copyJob2.getCommand().addArgument(catPath + " " +inputFilePath+ " >> dir1/output");

--- a/seqware-pipeline/src/main/java/net/sourceforge/seqware/pipeline/workflowV2/engine/oozie/object/OozieProvisionFileJob.java
+++ b/seqware-pipeline/src/main/java/net/sourceforge/seqware/pipeline/workflowV2/engine/oozie/object/OozieProvisionFileJob.java
@@ -19,8 +19,8 @@ public class OozieProvisionFileJob extends OozieJob {
   public OozieProvisionFileJob(AbstractJob job, SqwFile file, String name, String oozie_working_dir, boolean useSge,
                                File seqwareJar, String slotsSgeParamFormat, String maxMemorySgeParamFormat) {
     super(job, name, oozie_working_dir, useSge, seqwareJar, slotsSgeParamFormat, maxMemorySgeParamFormat);
-    // oozie provision file jobs should only require 2GB
-    job.setMaxMemory("2500");
+    // oozie provision file jobs should only require 2GB, leaving a margin of safety
+    job.setMaxMemory("3000");
     this.file = file;
   }
 

--- a/seqware-pipeline/src/main/java/net/sourceforge/seqware/pipeline/workflowV2/engine/oozie/object/WorkflowApp.java
+++ b/seqware-pipeline/src/main/java/net/sourceforge/seqware/pipeline/workflowV2/engine/oozie/object/WorkflowApp.java
@@ -188,8 +188,8 @@ public class WorkflowApp {
       }
     }
     
-    // 2GB should be more than enough for start_0 based on metrics in PDE dev
-    abstractRootJob.setMaxMemory("2500");
+    // 2GB should be more than enough for start_0 based on metrics in PDE dev, leaving a margin of safety
+    abstractRootJob.setMaxMemory("3000");
     OozieJob oozieRootJob = new OozieBashJob(abstractRootJob, "start_" + this.jobs.size(), this.uniqueWorkingDir, this.useSge,
                                   this.seqwareJar, this.threadsSgeParamFormat, this.maxMemorySgeParamFormat);
     oozieRootJob.setMetadataWriteback(metadatawriteback);


### PR DESCRIPTION
provision file steps.

Cannot trim below 2500m despite us only using 500m heap.
