### PR TITLE
Feature/seqware 1889

### DIFF
--- a/seqware-webservice/src/main/resources/file-provenance-report.sql
+++ b/seqware-webservice/src/main/resources/file-provenance-report.sql
@@ -72,7 +72,7 @@ union
     join lane l on l.lane_id = pl.lane_id
     join sequencer_run sr on sr.sequencer_run_id = l.sequencer_run_id
     join processing_files pf on pf.processing_id = pl.processing_id
-    WHERE pf.file_id NOT IN (select f.file_id from study_report_ids_premerge f)
+    WHERE NOT EXISTS (select null from study_report_ids_premerge f where pf.file_id = f.file_id)
 union all 
     select * from study_report_ids_premerge
 )


### PR DESCRIPTION
Return paths in the file provenance report going through processing_lanes that correspond to files that do not otherwise appear in the file provenance report. 

To avoid a combinatorial explosion of paths, we do not link these paths through ius/sample and instead provide empty values for sample on up. 
