### PR TITLE
Feature/seqware 1981

### DIFF
--- a/seqware-webservice/src/main/resources/io/seqware/report.clj
+++ b/seqware-webservice/src/main/resources/io/seqware/report.clj
@@ -72,6 +72,7 @@
               "File Md5sum"
               "File Size"
               "File Description"
+              "Path Skip"
               "Skip"])
 
 (def ^:dynamic *db-spec*


### PR DESCRIPTION
This considers all paths to a file and sets skip to true if any path is skipped. 
A scalar subquery is used to join workflow run input files (as recorded by deciders). 
We also threw in workflow and workflow run attributes for kicks if they are needed for the future. 
