### PR TITLE
Implements md5sum and file size recording during provision files (out)

### DIFF
--- a/seqware-common/src/main/java/io/seqware/pipeline/SqwKeys.java
+++ b/seqware-common/src/main/java/io/seqware/pipeline/SqwKeys.java
@@ -18,49 +18,50 @@
 package io.seqware.pipeline;
 
 import io.seqware.Engines;
+import java.util.Arrays;
 
 /**
  * This binds together all of the keys in the .seqware/settings file as a precursor to auto-generating documentation for them.
- * 
+ *
  * TODO: Remove keys with periods in them
- * 
+ *
  * @author dyuen
  */
 public enum SqwKeys {
     // @formatter:off
-    SW_METADATA_METHOD(null, Categories.COMMON, true, "SeqWare MetaDB communication method, can be 'database' or 'webservice' or 'inmemory' or 'none'", "webservice", "database", "webservice", "inmemory", "none"), 
-    AWS_ACCESS_KEY(null, Categories.COMMON, false, "Amazon cloud settings. Only used if reading and writing to S3 buckets.", "FILLMEIN"), 
-    AWS_SECRET_KEY(null, Categories.COMMON, false, "Amazon cloud settings. Only used if reading and writing to S3 buckets.", "FILLMEIN"), 
-    
+    SW_METADATA_METHOD(null, Categories.COMMON, true, "SeqWare MetaDB communication method, can be 'database' or 'webservice' or 'inmemory' or 'none'", "webservice", "database", "webservice", "inmemory", "none"),
+    AWS_ACCESS_KEY(null, Categories.COMMON, false, "Amazon cloud settings. Only used if reading and writing to S3 buckets.", "FILLMEIN"),
+    AWS_SECRET_KEY(null, Categories.COMMON, false, "Amazon cloud settings. Only used if reading and writing to S3 buckets.", "FILLMEIN"),
+
     SW_REST_URL(null, Categories.COMMON_WS, true, "Specify the URL for the seqware-webservice", "http://localhost:8080/SeqWareWebService"),
-    SW_REST_USER(null, Categories.COMMON_WS, true, "Specify the username for the seqware-webservice", "admin"), 
-    SW_REST_PASS(null, Categories.COMMON_WS, true, "Specify the password for the seqware-webservice", "admin@admin.com"), 
-    SW_DB_USER(null, Categories.COMMON_DB, false, "JDBC user for the seqware metadb", "seqware"), 
-    SW_DB_PASS(null, Categories.COMMON_DB, false, "JDBC password for the seqware metadb", "seqware"), 
-    SW_DB_SERVER(null, Categories.COMMON_DB, false, "Host for the metadb", "localhost"), 
-    SW_DB(null, Categories.COMMON_DB, false, "database name", "seqware_meta_db"), 
+    SW_REST_USER(null, Categories.COMMON_WS, true, "Specify the username for the seqware-webservice", "admin"),
+    SW_REST_PASS(null, Categories.COMMON_WS, true, "Specify the password for the seqware-webservice", "admin@admin.com"),
+    SW_DB_USER(null, Categories.COMMON_DB, false, "JDBC user for the seqware metadb", "seqware"),
+    SW_DB_PASS(null, Categories.COMMON_DB, false, "JDBC password for the seqware metadb", "seqware"),
+    SW_DB_SERVER(null, Categories.COMMON_DB, false, "Host for the metadb", "localhost"),
+    SW_DB(null, Categories.COMMON_DB, false, "database name", "seqware_meta_db"),
     SW_DEFAULT_WORKFLOW_ENGINE(null, Categories.SCHEDULE_LAUNCH, true,
-            "the default engine to use if otherwise unspecified (one of: "+Engines.ENGINES_LIST+")", "oozie-sge"), 
+            "the default engine to use if otherwise unspecified (one of: "+Engines.ENGINES_LIST+")", "oozie-sge"),
     SW_BUNDLE_DIR(null, Categories.INSTALL_LAUNCH, true, "The directory containing bundle directories (into which bundle archives are unzipped)",
-            "/home/seqware/SeqWare/provisioned-bundles"), 
+            "/home/seqware/SeqWare/provisioned-bundles"),
     SW_BUNDLE_REPO_DIR(null, Categories.INSTALL, true,
             "The directory containing bundle archives (into which a bundle archive is first copied during install)",
-            "/home/seqware/SeqWare/released-bundles"), 
-    BUNDLE_COMPRESSION(null, Categories.INSTALL, false, "Default is to use compression, this can be set to OFF to disable compression", "ON"), 
-    OOZIE_URL(null, Categories.LAUNCH, true, "URL for the Oozie webservice", "http://localhost:11000/oozie"), 
-    OOZIE_APP_ROOT(null, Categories.LAUNCH, true, "HDFS directory for storing workflow xml", "seqware_workflow"), 
-    OOZIE_JOBTRACKER(null, Categories.LAUNCH, true, "Hadoop job tracker, used to schedule jobs for oozie-hadoop engine", "localhost:8021"), 
-    OOZIE_NAMENODE(null, Categories.LAUNCH, true, "Hadoop name node, possibly redundant (should be refactored)", "hdfs://localhost:8020"), 
-    OOZIE_QUEUENAME(null, Categories.LAUNCH, true, "Hadoop queue onto which to schedule jobs", "default"), 
+            "/home/seqware/SeqWare/released-bundles"),
+    BUNDLE_COMPRESSION(null, Categories.INSTALL, false, "Default is to use compression, this can be set to OFF to disable compression", "ON"),
+    OOZIE_URL(null, Categories.LAUNCH, true, "URL for the Oozie webservice", "http://localhost:11000/oozie"),
+    OOZIE_APP_ROOT(null, Categories.LAUNCH, true, "HDFS directory for storing workflow xml", "seqware_workflow"),
+    OOZIE_JOBTRACKER(null, Categories.LAUNCH, true, "Hadoop job tracker, used to schedule jobs for oozie-hadoop engine", "localhost:8021"),
+    OOZIE_NAMENODE(null, Categories.LAUNCH, true, "Hadoop name node, possibly redundant (should be refactored)", "hdfs://localhost:8020"),
+    OOZIE_QUEUENAME(null, Categories.LAUNCH, true, "Hadoop queue onto which to schedule jobs", "default"),
     OOZIE_WORK_DIR(null, Categories.LAUNCH, true,
-            "Working directory where your workflow steps execute and where we store generated scripts and logs", "/usr/tmp/seqware-oozie"), 
-    OOZIE_RETRY_MAX(null, Categories.LAUNCH, false, "Number of times that Oozie will retry user steps in workflows", "5"), 
-    OOZIE_RETRY_INTERVAL(null, Categories.LAUNCH, false, "Minutes to wait before retry for user steps in workflows", "5"), 
+            "Working directory where your workflow steps execute and where we store generated scripts and logs", "/usr/tmp/seqware-oozie"),
+    OOZIE_RETRY_MAX(null, Categories.LAUNCH, false, "Number of times that Oozie will retry user steps in workflows", "5"),
+    OOZIE_RETRY_INTERVAL(null, Categories.LAUNCH, false, "Minutes to wait before retry for user steps in workflows", "5"),
     OOZIE_BATCH_THRESHOLD(null, Categories.LAUNCH, false,
-            "Above this threshold, provision file events on the same job/workflow will be batched together", "10"), 
-    OOZIE_BATCH_SIZE(null, Categories.LAUNCH, false, "Number of provision file events that should be batched together", "100"), 
+            "Above this threshold, provision file events on the same job/workflow will be batched together", "10"),
+    OOZIE_BATCH_SIZE(null, Categories.LAUNCH, false, "Number of provision file events that should be batched together", "100"),
     FS_HDFS_IMPL("FS.HDFS.IMPL", Categories.LAUNCH, true, "HDFS implementation class", "org.apache.hadoop.hdfs.DistributedFileSystem"),
-    OOZIE_SGE_THREADS_PARAM_FORMAT(null, Categories.LAUNCH, false, 
+    OOZIE_SGE_THREADS_PARAM_FORMAT(null, Categories.LAUNCH, false,
             "Only used for 'oozie-sge' engine. Format of qsub flag for specifying number of threads. "
                     + "If present, ${threads} will be replaced with the job-specific value.", "-pe serial ${threads}"),
     OOZIE_SGE_MAX_MEMORY_PARAM_FORMAT(null , Categories.LAUNCH, true, "Format of qsub flag for specifying the max memory. "
@@ -70,6 +71,7 @@ public enum SqwKeys {
     SW_LOCK_ID(null, Categories.ADMIN, false, "Used to override the JUnique lock used to ensure that utilities don't run concurrently","seqware"),
     SW_ENCRYPT_KEY(null, Categories.ADMIN, false,"Legacy key used to encrypt provisioned files", "seqware"),
     SW_DECRYPT_KEY(null, Categories.ADMIN, false,"Legacy key used to decrypt provisioned files", "seqware"),
+    SW_PROVISION_FILES_MD5(null, Categories.LAUNCH, false, "Used to determine whether provisioned (out) files should be run through MD5 before and after provisioning", "true"),
     BASIC_TEST_DB_HOST(null, Categories.TESTING, false,"Used to designate a database for integration tests","localhost"),
     BASIC_TEST_DB_NAME(null, Categories.TESTING, false,"Used to designate a database name for integration tests","seqware_meta_db"),
     BASIC_TEST_DB_USER(null, Categories.TESTING, false,"Used to designate a database username for integration tests","seqware"),
@@ -100,7 +102,7 @@ public enum SqwKeys {
 
     /**
      * Returns the name of the key to be used in the seqware settings file
-     * 
+     *
      * @return
      */
     public String getSettingKey() {
@@ -112,7 +114,7 @@ public enum SqwKeys {
 
     /**
      * For documentation
-     * 
+     *
      * @return the category
      */
     public Categories getCategory() {
@@ -121,7 +123,7 @@ public enum SqwKeys {
 
     /**
      * For documentation
-     * 
+     *
      * @return the description
      */
     public String getDescription() {
@@ -130,7 +132,7 @@ public enum SqwKeys {
 
     /**
      * This is the value used to populate our auto-generated documentation
-     * 
+     *
      * @return the defaultValue
      */
     public String getDefaultValue() {
@@ -139,16 +141,16 @@ public enum SqwKeys {
 
     /**
      * For documentation
-     * 
+     *
      * @return the possibleValues
      */
     public String[] getPossibleValues() {
-        return possibleValues;
+        return Arrays.copyOf(possibleValues, possibleValues.length);
     }
 
     /**
      * Return whether or not this variable is generally required for a typical Oozie-sge install with metadata.
-     * 
+     *
      * @return the required
      */
     public boolean isRequired() {
@@ -157,20 +159,20 @@ public enum SqwKeys {
 
     public enum Categories {
         // @formatter:off
-        COMMON("Common Seqware settings"), 
-        COMMON_WS("Seqware webservice settings. Only used if SW_METADATA_METHOD=webservice"), 
+        COMMON("Common Seqware settings"),
+        COMMON_WS("Seqware webservice settings. Only used if SW_METADATA_METHOD=webservice"),
         COMMON_DB(
-                "Seqware database settings. Only used if SW_METADATA_METHOD=database and by the database check utility"), 
+                "Seqware database settings. Only used if SW_METADATA_METHOD=database and by the database check utility"),
         SCHEDULE_LAUNCH(
-                "Settings used by scheduling and launching bundles"), 
+                "Settings used by scheduling and launching bundles"),
         INSTALL_LAUNCH(
-                "Settings used by both installing and launching bundles"), 
+                "Settings used by both installing and launching bundles"),
         INSTALL(
-                "Settings used to configure the installation of workflow bundles"), 
+                "Settings used to configure the installation of workflow bundles"),
         LAUNCH(
-                "Oozie engine settings. Only used for both 'oozie' and 'oozie-sge' engines."), 
+                "Oozie engine settings. Only used for both 'oozie' and 'oozie-sge' engines."),
         OOZIE_SGE(
-                "Oozie-SGE engine settings. Only used for 'oozie-sge' engine."), 
+                "Oozie-SGE engine settings. Only used for 'oozie-sge' engine."),
         ADMIN("Settings used for administrators"),
         TESTING("Used for regression testing");
         // @formatter:on
@@ -183,7 +185,7 @@ public enum SqwKeys {
 
         /**
          * For documentation
-         * 
+         *
          * @return the categoryDescription
          */
         public String getCategoryDescription() {

--- a/seqware-common/src/main/java/net/sourceforge/seqware/common/business/FileService.java
+++ b/seqware-common/src/main/java/net/sourceforge/seqware/common/business/FileService.java
@@ -10,7 +10,7 @@ import net.sourceforge.seqware.common.model.Registration;
  * <p>
  * FileService interface.
  * </p>
- * 
+ *
  * @author boconnor
  * @version $Id: $Id
  */
@@ -23,7 +23,7 @@ public interface FileService {
      * <p>
      * setFileDAO.
      * </p>
-     * 
+     *
      * @param fileDAO
      *            a {@link net.sourceforge.seqware.common.dao.FileDAO} object.
      */
@@ -33,29 +33,30 @@ public interface FileService {
      * <p>
      * insert.
      * </p>
-     * 
+     *
      * @param file
      *            a {@link net.sourceforge.seqware.common.model.File} object.
      */
-    public void insert(File file);
+    public Integer insert(File file);
 
     /**
      * <p>
      * insert.
      * </p>
-     * 
+     *
      * @param registration
      *            a {@link net.sourceforge.seqware.common.model.Registration} object.
      * @param file
      *            a {@link net.sourceforge.seqware.common.model.File} object.
+     * @return sw_accession for created file
      */
-    public void insert(Registration registration, File file);
+    public Integer insert(Registration registration, File file);
 
     /**
      * <p>
      * update.
      * </p>
-     * 
+     *
      * @param registration
      *            a {@link net.sourceforge.seqware.common.model.Registration} object.
      * @param file
@@ -67,7 +68,7 @@ public interface FileService {
      * <p>
      * update.
      * </p>
-     * 
+     *
      * @param file
      *            a {@link net.sourceforge.seqware.common.model.File} object.
      */
@@ -77,7 +78,7 @@ public interface FileService {
      * <p>
      * delete.
      * </p>
-     * 
+     *
      * @param file
      * @param deleteRealFiles
      */
@@ -87,7 +88,7 @@ public interface FileService {
      * <p>
      * deleteAll.
      * </p>
-     * 
+     *
      * @param file
      * @param deleteRealFiles
      */
@@ -97,7 +98,7 @@ public interface FileService {
      * <p>
      * findByID.
      * </p>
-     * 
+     *
      * @param id
      *            a {@link java.lang.Integer} object.
      * @return a {@link net.sourceforge.seqware.common.model.File} object.
@@ -108,7 +109,7 @@ public interface FileService {
      * <p>
      * findByPath.
      * </p>
-     * 
+     *
      * @param path
      *            a {@link java.lang.String} object.
      * @return a {@link net.sourceforge.seqware.common.model.File} object.
@@ -119,7 +120,7 @@ public interface FileService {
      * <p>
      * findBySWAccession.
      * </p>
-     * 
+     *
      * @param swAccession
      *            a {@link java.lang.Integer} object.
      * @return a {@link net.sourceforge.seqware.common.model.File} object.
@@ -130,7 +131,7 @@ public interface FileService {
      * <p>
      * findByOwnerId.
      * </p>
-     * 
+     *
      * @param registrationId
      *            a {@link java.lang.Integer} object.
      * @return a {@link java.util.List} object.
@@ -141,7 +142,7 @@ public interface FileService {
      * <p>
      * getFiles.
      * </p>
-     * 
+     *
      * @param fileId
      *            a {@link java.lang.Integer} object.
      * @return a {@link java.util.List} object.
@@ -152,7 +153,7 @@ public interface FileService {
      * <p>
      * getFiles.
      * </p>
-     * 
+     *
      * @param fileId
      *            a {@link java.lang.Integer} object.
      * @param metaType
@@ -165,7 +166,7 @@ public interface FileService {
      * <p>
      * setWithHasFile.
      * </p>
-     * 
+     *
      * @param list
      *            a {@link java.util.Set} object.
      * @param metaType
@@ -178,7 +179,7 @@ public interface FileService {
      * <p>
      * isExists.
      * </p>
-     * 
+     *
      * @param fileName
      *            a {@link java.lang.String} object.
      * @param folderStore
@@ -191,7 +192,7 @@ public interface FileService {
      * <p>
      * updateDetached.
      * </p>
-     * 
+     *
      * @param file
      *            a {@link net.sourceforge.seqware.common.model.File} object.
      * @return a {@link net.sourceforge.seqware.common.model.File} object.
@@ -202,7 +203,7 @@ public interface FileService {
      * <p>
      * updateDetached.
      * </p>
-     * 
+     *
      * @param registration
      *            a {@link net.sourceforge.seqware.common.model.Registration} object.
      * @param file
@@ -215,7 +216,7 @@ public interface FileService {
      * <p>
      * findByCriteria.
      * </p>
-     * 
+     *
      * @param criteria
      *            a {@link java.lang.String} object.
      * @param isCaseSens
@@ -228,7 +229,7 @@ public interface FileService {
      * <p>
      * list.
      * </p>
-     * 
+     *
      * @return a {@link java.util.List} object.
      */
     public List<File> list();

--- a/seqware-common/src/main/java/net/sourceforge/seqware/common/business/impl/FileServiceImpl.java
+++ b/seqware-common/src/main/java/net/sourceforge/seqware/common/business/impl/FileServiceImpl.java
@@ -17,7 +17,7 @@ import org.apache.commons.logging.LogFactory;
  * <p>
  * FileServiceImpl class.
  * </p>
- * 
+ *
  * @author boconnor
  * @version $Id: $Id
  */
@@ -37,10 +37,10 @@ public class FileServiceImpl implements FileService {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * Sets a private member variable with an instance of an implementation of FileDAO. This method is called by the Spring framework at run
      * time.
-     * 
+     *
      * @param dao
      * @see FileDAO
      */
@@ -51,17 +51,19 @@ public class FileServiceImpl implements FileService {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * Inserts an instance of File into the database.
+     *
+     * @return
      */
     @Override
-    public void insert(File file) {
-        fileDAO.insert(file);
+    public Integer insert(File file) {
+        return fileDAO.insert(file);
     }
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * Updates an instance of File in the database.
      */
     @Override
@@ -71,7 +73,7 @@ public class FileServiceImpl implements FileService {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @param file
      * @param deleteRealFiles
      */
@@ -97,7 +99,7 @@ public class FileServiceImpl implements FileService {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @param files
      * @param deleteRealFiles
      */
@@ -168,7 +170,7 @@ public class FileServiceImpl implements FileService {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @param fileId
      */
     @Override
@@ -241,8 +243,8 @@ public class FileServiceImpl implements FileService {
 
     /** {@inheritDoc} */
     @Override
-    public void insert(Registration registration, File file) {
-        fileDAO.insert(registration, file);
+    public Integer insert(Registration registration, File file) {
+        return fileDAO.insert(registration, file);
     }
 
     /** {@inheritDoc} */

--- a/seqware-common/src/main/java/net/sourceforge/seqware/common/dao/FileDAO.java
+++ b/seqware-common/src/main/java/net/sourceforge/seqware/common/dao/FileDAO.java
@@ -10,7 +10,7 @@ import org.springframework.web.multipart.MultipartFile;
  * <p>
  * FileDAO interface.
  * </p>
- * 
+ *
  * @author boconnor
  * @version $Id: $Id
  */
@@ -20,29 +20,31 @@ public interface FileDAO {
      * <p>
      * insert.
      * </p>
-     * 
+     *
      * @param file
      *            a {@link net.sourceforge.seqware.common.model.File} object.
+     * @return
      */
-    public void insert(File file);
+    public Integer insert(File file);
 
     /**
      * <p>
      * insert.
      * </p>
-     * 
+     *
      * @param registration
      *            a {@link net.sourceforge.seqware.common.model.Registration} object.
      * @param file
      *            a {@link net.sourceforge.seqware.common.model.File} object.
+     * @return
      */
-    public void insert(Registration registration, File file);
+    public Integer insert(Registration registration, File file);
 
     /**
      * <p>
      * update.
      * </p>
-     * 
+     *
      * @param file
      *            a {@link net.sourceforge.seqware.common.model.File} object.
      */
@@ -52,7 +54,7 @@ public interface FileDAO {
      * <p>
      * update.
      * </p>
-     * 
+     *
      * @param registration
      *            a {@link net.sourceforge.seqware.common.model.Registration} object.
      * @param file
@@ -64,7 +66,7 @@ public interface FileDAO {
      * <p>
      * delete.
      * </p>
-     * 
+     *
      * @param file
      *            a {@link net.sourceforge.seqware.common.model.File} object.
      */
@@ -74,7 +76,7 @@ public interface FileDAO {
      * <p>
      * deleteAll.
      * </p>
-     * 
+     *
      * @param files
      *            a {@link java.util.List} object.
      */
@@ -84,7 +86,7 @@ public interface FileDAO {
      * <p>
      * deleteAllWithFolderStore.
      * </p>
-     * 
+     *
      * @param list
      *            a {@link java.util.List} object.
      */
@@ -94,7 +96,7 @@ public interface FileDAO {
      * <p>
      * findByID.
      * </p>
-     * 
+     *
      * @param id
      *            a {@link java.lang.Integer} object.
      * @return a {@link net.sourceforge.seqware.common.model.File} object.
@@ -105,7 +107,7 @@ public interface FileDAO {
      * <p>
      * findByPath.
      * </p>
-     * 
+     *
      * @param path
      *            a {@link java.lang.String} object.
      * @return a {@link net.sourceforge.seqware.common.model.File} object.
@@ -116,7 +118,7 @@ public interface FileDAO {
      * <p>
      * saveFile.
      * </p>
-     * 
+     *
      * @param uploadFile
      *            a {@link org.springframework.web.multipart.MultipartFile} object.
      * @param folderStore
@@ -133,7 +135,7 @@ public interface FileDAO {
      * <p>
      * findBySWAccession.
      * </p>
-     * 
+     *
      * @param swAccession
      *            a {@link java.lang.Integer} object.
      * @return a {@link net.sourceforge.seqware.common.model.File} object.
@@ -144,7 +146,7 @@ public interface FileDAO {
      * <p>
      * updateDetached.
      * </p>
-     * 
+     *
      * @param file
      *            a {@link net.sourceforge.seqware.common.model.File} object.
      * @return a {@link net.sourceforge.seqware.common.model.File} object.
@@ -155,7 +157,7 @@ public interface FileDAO {
      * <p>
      * updateDetached.
      * </p>
-     * 
+     *
      * @param registration
      *            a {@link net.sourceforge.seqware.common.model.Registration} object.
      * @param file
@@ -168,7 +170,7 @@ public interface FileDAO {
      * <p>
      * findByOwnerId.
      * </p>
-     * 
+     *
      * @param registrationId
      *            a {@link java.lang.Integer} object.
      * @return a {@link java.util.List} object.
@@ -179,7 +181,7 @@ public interface FileDAO {
      * <p>
      * findByCriteria.
      * </p>
-     * 
+     *
      * @param criteria
      *            a {@link java.lang.String} object.
      * @param isCaseSens
@@ -192,7 +194,7 @@ public interface FileDAO {
      * <p>
      * list.
      * </p>
-     * 
+     *
      * @return a {@link java.util.List} object.
      */
     public List<File> list();

--- a/seqware-common/src/main/java/net/sourceforge/seqware/common/dao/hibernate/FileDAOHibernate.java
+++ b/seqware-common/src/main/java/net/sourceforge/seqware/common/dao/hibernate/FileDAOHibernate.java
@@ -25,7 +25,7 @@ import org.springframework.web.multipart.MultipartFile;
  * <p>
  * FileDAOHibernate class.
  * </p>
- * 
+ *
  * @author boconnor
  * @version $Id: $Id
  */
@@ -44,18 +44,19 @@ public class FileDAOHibernate extends HibernateDaoSupport implements FileDAO {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * Inserts an instance of File into the database.
      */
     @Override
-    public void insert(File file) {
-
+    public Integer insert(File file) {
         this.getHibernateTemplate().save(file);
+        this.getSession().flush();
+        return file.getSwAccession();
     }
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * Updates an instance of File in the database.
      */
     @Override
@@ -66,7 +67,7 @@ public class FileDAOHibernate extends HibernateDaoSupport implements FileDAO {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * Updates an instance of File in the database.
      */
     @Override
@@ -109,7 +110,7 @@ public class FileDAOHibernate extends HibernateDaoSupport implements FileDAO {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * Finds an instance of File in the database by the File Path.
      */
     @Override
@@ -126,7 +127,7 @@ public class FileDAOHibernate extends HibernateDaoSupport implements FileDAO {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * Finds an instance of File in the database by the File ID.
      */
     @Override
@@ -208,7 +209,7 @@ public class FileDAOHibernate extends HibernateDaoSupport implements FileDAO {
 
     /**
      * Removes results matching by filePath, but not FileName.
-     * 
+     *
      * @param files
      * @param crit
      * @param isCaseSens
@@ -300,15 +301,16 @@ public class FileDAOHibernate extends HibernateDaoSupport implements FileDAO {
 
     /** {@inheritDoc} */
     @Override
-    public void insert(Registration registration, File file) {
+    public Integer insert(Registration registration, File file) {
         if (registration == null) {
             localLogger.error("FileDAOHibernate insert registration is null");
         } else if (registration.isLIMSAdmin() || file.givesPermission(registration)) {
             localLogger.info("insert file object");
-            insert(file);
+            return insert(file);
         } else {
             localLogger.error("FileDAOHibernate insert not authorized");
         }
+        return null;
     }
 
     /** {@inheritDoc} */

--- a/seqware-common/src/main/java/net/sourceforge/seqware/common/metadata/MetadataWS.java
+++ b/seqware-common/src/main/java/net/sourceforge/seqware/common/metadata/MetadataWS.java
@@ -1299,6 +1299,7 @@ public class MetadataWS implements Metadata {
                     modelFile.setMd5sum(file.getMd5sum());
                     modelFile.setSize(file.getSize());
                     modelFile.setFileAttributes(file.getAnnotations());
+                    modelFile.setSkip(false);
 
                     modelFile = ll.addFile(modelFile);
 
@@ -1943,7 +1944,7 @@ public class MetadataWS implements Metadata {
      */
     @Override
     public String getWorkflowRunReport(int workflowRunSWID) {
-        String report = (String) ll.getString("/reports/workflowruns/" + workflowRunSWID);
+        String report = ll.getString("/reports/workflowruns/" + workflowRunSWID);
         return report;
     }
 
@@ -1952,7 +1953,7 @@ public class MetadataWS implements Metadata {
      */
     @Override
     public String getWorkflowRunReportStdErr(int workflowRunSWID) {
-        return ((String) ll.getString("/reports/workflowruns/" + workflowRunSWID + "/stderr"));
+        return ll.getString("/reports/workflowruns/" + workflowRunSWID + "/stderr");
     }
 
     /**
@@ -1960,7 +1961,7 @@ public class MetadataWS implements Metadata {
      */
     @Override
     public String getWorkflowRunReportStdOut(int workflowRunSWID) {
-        return ((String) ll.getString("/reports/workflowruns/" + workflowRunSWID + "/stdout"));
+        return ll.getString("/reports/workflowruns/" + workflowRunSWID + "/stdout");
     }
 
     /**
@@ -2018,9 +2019,9 @@ public class MetadataWS implements Metadata {
         }
         String report;
         if (workflowSWID != null) {
-            report = (String) ll.getString("/reports/workflows/" + workflowSWID + "/runs?" + constraintQuery.toString());
+            report = ll.getString("/reports/workflows/" + workflowSWID + "/runs?" + constraintQuery.toString());
         } else {
-            report = (String) ll.getString("/reports/workflowruns?" + constraintQuery.toString());
+            report = ll.getString("/reports/workflowruns?" + constraintQuery.toString());
         }
         return report;
     }
@@ -2668,7 +2669,7 @@ public class MetadataWS implements Metadata {
      * ll.updateFile("/" + fileSWID, obj); } catch (IOException ex) { Log.error("IOException while updating study " + fileSWID + " " +
      * ex.getMessage()); } catch (JAXBException ex) { Log.error("JAXBException while updating study " + fileSWID + " " + ex.getMessage()); }
      * catch (ResourceException ex) { Log.error("ResourceException while updating study " + fileSWID + " " + ex.getMessage()); }
-     * 
+     *
      * }
      */
     protected class LowLevel {
@@ -2900,10 +2901,6 @@ public class MetadataWS implements Metadata {
                 return list.getList();
             }
             return null;
-        }
-
-        private List<Experiment> findExperiments() throws IOException, JAXBException {
-            return findExperiments("/experiments");
         }
 
         private List<Experiment> findExperiments(String searchString) throws IOException, JAXBException {

--- a/seqware-webservice/src/main/java/net/sourceforge/seqware/webservice/resources/tables/FileResource.java
+++ b/seqware-webservice/src/main/java/net/sourceforge/seqware/webservice/resources/tables/FileResource.java
@@ -74,21 +74,21 @@ public class FileResource extends DatabaseResource {
 
         if (queryValues.get("id") != null) {
             JaxbObject<File> jaxbTool = new JaxbObject<>();
-            File p = (File) testIfNull(ss.findByID(parseClientInt(queryValues.get("id"))));
+            File p = testIfNull(ss.findByID(parseClientInt(queryValues.get("id"))));
 
             File dto = copier.hibernate2dto(File.class, p);
             Document line = XmlTools.marshalToDocument(jaxbTool, dto);
             getResponse().setEntity(XmlTools.getRepresentation(line));
         } else if (queryValues.get("path") != null) {
             JaxbObject<File> jaxbTool = new JaxbObject<>();
-            File p = (File) testIfNull(ss.findByPath(queryValues.get("path")));
+            File p = testIfNull(ss.findByPath(queryValues.get("path")));
 
             File dto = copier.hibernate2dto(File.class, p);
             Document line = XmlTools.marshalToDocument(jaxbTool, dto);
             getResponse().setEntity(XmlTools.getRepresentation(line));
         } else {
             JaxbObject<FileList> jaxbTool = new JaxbObject<>();
-            List<File> files = (List<File>) testIfNull(ss.findByOwnerId(registration.getRegistrationId()));
+            List<File> files = testIfNull(ss.findByOwnerId(registration.getRegistrationId()));
             FileList eList = new FileList();
             eList.setList(new ArrayList());
 
@@ -140,14 +140,14 @@ public class FileResource extends DatabaseResource {
             Set<FileAttribute> fileAttributes = Sets.newTreeSet();
             fileAttributes.addAll(p.getFileAttributes());
             p.getFileAttributes().clear();
-            fileService.insert(registration, p);
-            File file = testIfNull(fileService.findByPath(p.getFilePath()));
+            Integer swAccession = fileService.insert(registration, p);
+            File file = testIfNull(fileService.findBySWAccession(swAccession));
             Hibernate3DtoCopier copier = new Hibernate3DtoCopier();
             File detachedFile = copier.hibernate2dto(File.class, file);
 
             // this is incredibly sad
             if (fileAttributes.size() > 0) {
-                File newFile = testIfNull(fileService.findByID(detachedFile.getFileId()));
+                File newFile = testIfNull(fileService.findBySWAccession(swAccession));
                 DatabaseIDResource.mergeAttributes(newFile.getFileAttributes(), fileAttributes, file);
                 fileService.update(registration, newFile);
             }


### PR DESCRIPTION
Also, a fix for the webservice where it was assuming that file paths
were unique.

Above functionality is default but can be disabled with a new
.seqware/settings key (SW_PROVISION_FILES_MD5)
