### PR TITLE
Feature/seqware 2037

### DIFF
--- a/seqware-ext-admin-testing/src/main/java/net/sourceforge/seqware/pipeline/plugins/ITUtility.java
+++ b/seqware-ext-admin-testing/src/main/java/net/sourceforge/seqware/pipeline/plugins/ITUtility.java
@@ -100,6 +100,19 @@ public class ITUtility {
         return output;
     }
 
+
+    public static String runSeqWareJarDirect(String parameters, int expectedReturnValue, File workingDir) throws IOException {
+        File jar = retrieveFullAssembledJar();
+
+        if (workingDir == null) {
+            workingDir = Files.createTempDir();
+            workingDir.deleteOnExit();
+        }
+
+        String line = "java -cp " + jar.getAbsolutePath() + " " + parameters;
+        return runArbitraryCommand(line, expectedReturnValue, workingDir);
+    }
+
     /**
      * 
      * @param seqTargetDir

--- a/seqware-ext-testing/src/test/java/net/sourceforge/seqware/pipeline/modules/GenericCommandRunnerET.java
+++ b/seqware-ext-testing/src/test/java/net/sourceforge/seqware/pipeline/modules/GenericCommandRunnerET.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Random;
 
@@ -67,7 +68,9 @@ public class GenericCommandRunnerET {
 
     @Test
     public void testProvisionTwice() throws IOException {
-        File createTempDir = Files.createTempDir();
+        File createTempDir = com.google.common.io.Files.createTempDir();
+        final Path tempFile = java.nio.file.Files.createTempFile("test", "test");
+        tempFile.toFile().createNewFile();
 
         Random generator = new Random();
         String listCommand = "net.sourceforge.seqware.pipeline.runner.Runner " + "--metadata "
@@ -76,7 +79,7 @@ public class GenericCommandRunnerET {
                 + "--metadata-processing-accession-file-lock "
                 + createTempDir.getAbsolutePath() + "/s4419139_pfo_5_accession.lock " + "--module "
                 + "net.sourceforge.seqware.pipeline.modules.utilities.ProvisionFiles " + "-- " + "--input-file-metadata "
-                + "pfo::txt/plain::/datastore/oozie-83ec61c6-d8e7-46a7-a98c-ed9833a39cfb/dir1/output " + "--output-file "
+                + "pfo::txt/plain::" + tempFile.toFile().getAbsolutePath() + " " + "--output-file "
                 + "./seqware-results/CheckProvision_1.0-SNAPSHOT/19614578/dir1/output " + "--force-copy " + "--annotation-file "
                 + createTempDir.getAbsolutePath() + "/generated-scripts/s4419139_pfo_5.annotations.tsv";
 

--- a/seqware-ext-testing/src/test/java/net/sourceforge/seqware/pipeline/modules/GenericCommandRunnerET.java
+++ b/seqware-ext-testing/src/test/java/net/sourceforge/seqware/pipeline/modules/GenericCommandRunnerET.java
@@ -18,15 +18,18 @@ package net.sourceforge.seqware.pipeline.modules;
 
 import com.google.common.base.Splitter;
 import com.google.common.io.Files;
-import java.io.File;
-import java.io.IOException;
-import java.util.Random;
-import org.junit.Assert;
 import net.sourceforge.seqware.common.module.ReturnValue;
 import net.sourceforge.seqware.pipeline.plugins.ExtendedTestDatabaseCreator;
 import net.sourceforge.seqware.pipeline.plugins.ITUtility;
+import org.apache.commons.dbutils.handlers.ArrayHandler;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Random;
 
 /**
  * These tests support command-line tools found in the SeqWare User Tutorial, in this case, GenericCommandRunner
@@ -34,6 +37,8 @@ import org.junit.Test;
  * @author dyuen
  */
 public class GenericCommandRunnerET {
+
+    private final ExtendedTestDatabaseCreator dbCreator = new ExtendedTestDatabaseCreator();
 
     @BeforeClass
     public static void resetDatabase() {
@@ -58,6 +63,42 @@ public class GenericCommandRunnerET {
             }
         }
         Assert.assertTrue("did not find command in output", false);
+    }
+
+    @Test
+    public void testProvisionTwice() throws IOException {
+        File createTempDir = Files.createTempDir();
+
+        Random generator = new Random();
+        String listCommand = "net.sourceforge.seqware.pipeline.runner.Runner " + "--metadata "
+                + "--metadata-workflow-run-ancestor-accession " + "4419139 " + "--metadata-processing-accession-file "
+                + createTempDir.getAbsolutePath() + "/s4419139_pfo_5_accession "
+                + "--metadata-processing-accession-file-lock "
+                + createTempDir.getAbsolutePath() + "/s4419139_pfo_5_accession.lock " + "--module "
+                + "net.sourceforge.seqware.pipeline.modules.utilities.ProvisionFiles " + "-- " + "--input-file-metadata "
+                + "pfo::txt/plain::/datastore/oozie-83ec61c6-d8e7-46a7-a98c-ed9833a39cfb/dir1/output " + "--output-file "
+                + "./seqware-results/CheckProvision_1.0-SNAPSHOT/19614578/dir1/output " + "--force-copy " + "--annotation-file "
+                + createTempDir.getAbsolutePath() + "/generated-scripts/s4419139_pfo_5.annotations.tsv";
+
+        Object[] runQuerya = dbCreator.runQuery(new ArrayHandler(), "select count(*) from processing");
+        Object[] runQueryb = dbCreator.runQuery(new ArrayHandler(), "select count(*) from file");
+
+        String listOutput = ITUtility.runSeqWareJarDirect(listCommand, ReturnValue.SUCCESS, createTempDir);
+        // check the number of provision and file records
+        Object[] runQuery1 = dbCreator.runQuery(new ArrayHandler(), "select count(*) from processing");
+        Object[] runQuery2 = dbCreator.runQuery(new ArrayHandler(), "select count(*) from file");
+        // the number of provision and file records should have gone up by one
+        runQuerya[0] = (long)runQuerya[0] + 1;
+        runQueryb[0] = (long)runQueryb[0] + 1;
+        Assert.assertTrue("processing did not change" , Arrays.equals(runQuery1, runQuerya));
+        Assert.assertTrue("processing did not change" , Arrays.equals(runQuery2, runQueryb));
+
+        listOutput = ITUtility.runSeqWareJarDirect(listCommand, ReturnValue.SUCCESS, createTempDir);
+        // the number of provision and file records should not have changed
+        Object[] runQuery3 = dbCreator.runQuery(new ArrayHandler(), "select count(*) from processing");
+        Object[] runQuery4 = dbCreator.runQuery(new ArrayHandler(), "select count(*) from file");
+        Assert.assertTrue("processing changed" , Arrays.equals(runQuery1, runQuery3));
+        Assert.assertTrue("processing changed" , Arrays.equals(runQuery2, runQuery4));
     }
 
     @Test

--- a/seqware-ext-testing/src/test/java/net/sourceforge/seqware/pipeline/plugins/ProvisionFilesET.java
+++ b/seqware-ext-testing/src/test/java/net/sourceforge/seqware/pipeline/plugins/ProvisionFilesET.java
@@ -16,10 +16,6 @@
  */
 package net.sourceforge.seqware.pipeline.plugins;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Map;
-import java.util.Random;
 import net.sourceforge.seqware.common.module.ReturnValue;
 import net.sourceforge.seqware.common.util.Log;
 import net.sourceforge.seqware.common.util.configtools.ConfigTools;
@@ -27,6 +23,11 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Random;
 
 /**
  * These tests support command-line tools found in the SeqWare User Tutorial, in this case, ProvisionFiles

--- a/seqware-pipeline/src/main/java/io/seqware/pipeline/api/WorkflowEngine.java
+++ b/seqware-pipeline/src/main/java/io/seqware/pipeline/api/WorkflowEngine.java
@@ -38,28 +38,28 @@ public interface WorkflowEngine {
      * @param objectModel
      *            model of the workflow to prepare to run
      */
-    public void prepareWorkflow(AbstractWorkflowDataModel objectModel);
+    void prepareWorkflow(AbstractWorkflowDataModel objectModel);
 
     /**
      * Run the prepared workflow.
      * 
      * @return
      */
-    public ReturnValue runWorkflow();
+    ReturnValue runWorkflow();
 
     /**
      * An engine-specific token for this workflow run that can be used to lookup relevant runtime data.
      * 
      * @return the token
      */
-    public String getLookupToken();
+    String getLookupToken();
 
     /**
      * The working directory for the prepared workflow run, or null if not yet prepared or if not applicable for the concrete engine.
      * 
      * @return the working directory, or null
      */
-    public String getWorkingDirectory();
+    String getWorkingDirectory();
 
     /**
      * Watch a workflow and return running information until it completes.
@@ -69,6 +69,6 @@ public interface WorkflowEngine {
      * @param jobToken
      * @return
      */
-    public ReturnValue watchWorkflow(String jobToken);
+    ReturnValue watchWorkflow(String jobToken);
 
 }

--- a/seqware-pipeline/src/main/java/net/sourceforge/seqware/pipeline/workflowV2/engine/oozie/object/OozieJob.java
+++ b/seqware-pipeline/src/main/java/net/sourceforge/seqware/pipeline/workflowV2/engine/oozie/object/OozieJob.java
@@ -3,13 +3,6 @@ package net.sourceforge.seqware.pipeline.workflowV2.engine.oozie.object;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Lists;
 import io.seqware.pipeline.SqwKeys;
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 import net.sourceforge.seqware.common.util.Log;
 import net.sourceforge.seqware.common.util.configtools.ConfigTools;
 import net.sourceforge.seqware.pipeline.workflowV2.model.AbstractJob;
@@ -19,6 +12,14 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.jdom.Element;
 import org.jdom.Namespace;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 public abstract class OozieJob implements Comparable<OozieJob> {
     /**
@@ -64,7 +65,7 @@ public abstract class OozieJob implements Comparable<OozieJob> {
     protected final String threadsSgeParamFormat;
     protected final String maxMemorySgeParamFormat;
     protected final File scriptsDir;
-    private boolean useCheckFile = false;
+    private boolean useCheckFile = true;
     protected final File seqwareJar;
     private final StringTruncator stringTruncator;
 


### PR DESCRIPTION
Activate `metadata-processing-accession-file-lock` for even normal file provision to ensure non-repetition of provision events
