### PR TITLE
Make SGE use shortname as well as Oozie

### DIFF
--- a/seqware-pipeline/src/main/java/net/sourceforge/seqware/pipeline/workflowV2/engine/oozie/object/OozieJob.java
+++ b/seqware-pipeline/src/main/java/net/sourceforge/seqware/pipeline/workflowV2/engine/oozie/object/OozieJob.java
@@ -207,7 +207,7 @@ public abstract class OozieJob implements Comparable<OozieJob> {
         args.add("-o");
         args.add(scriptsDir.getAbsolutePath());
         args.add("-N");
-        args.add(longName);
+        args.add(shortName);
 
         if (jobObj.getQsubOptions() != null) {
             args.add(jobObj.getQsubOptions());


### PR DESCRIPTION
Explanation:
SGE was tracking a different name from Oozie, Oozie names must be shortened due to error condition E0724 in the Oozie code base. Basically action names are restricted to 50 characters so SeqWare needs to shorten names to this length. 

Oozie actually has a ticket for this to lengthen names to 100 characters https://issues.apache.org/jira/browse/OOZIE-2168 but it doesn't make it into Cloudera until 5.7.0 https://archive.cloudera.com/cdh5/cdh/5/oozie-4.1.0-cdh5.7.0.releasenotes.html 

TLDR: Match SGE to Oozie names for now, [expand to](https://seqware.github.io/apidocs/net/sourceforge/seqware/pipeline/workflowV2/engine/oozie/object/StringTruncator.html) 100 characters when we update to/past 5.7.0
